### PR TITLE
fix updateConceptScores, cache para Wikidata

### DIFF
--- a/TableMiner/LearningPhase/Learning.py
+++ b/TableMiner/LearningPhase/Learning.py
@@ -20,6 +20,9 @@ class Learning:
 
     def get_winning_concepts(self):
         return keys_with_max_value(self._conceptScores)
+    
+    def get_concepts(self):
+        return self._conceptScores
 
     def get_column(self):
         return self._column
@@ -219,7 +222,7 @@ class Learning:
                 entity_score[entity]['score'] = cf
                 entity_id = self._onto.get_entity_id(entity)
                 entity_score[entity]['id'] = entity_id
-
+        print("ENTITY SCORE" ,entity_score)
         if len(entity_score) > 0:
             winningEntity = max(entity_score, key=lambda k: entity_score[k]['score'])
             self._winning_entities_dict[winningEntity] = {'id': entity_score[winningEntity]['id'],

--- a/TableMiner/LearningPhase/Update.py
+++ b/TableMiner/LearningPhase/Update.py
@@ -6,7 +6,7 @@ from TableMiner.SCDection.TableAnnotation import TableColumnAnnotation as TA
 
 
 class TableLearning:
-    def __init__(self, table: pd.DataFrame, KB="DBPedia", NE_column: dict = None):
+    def __init__(self, table: pd.DataFrame, KB="Wikidata", NE_column: dict = None):
         self._table = table
         self._annotation_classes = {}
         self._NE_Column = {}
@@ -84,8 +84,9 @@ def updatePhase(currentLearnings: TableLearning):
         bow_domain = currentLearnings.domain_bow()
         for column_index in currentLearnings.get_annotation_class().keys():
             learning = currentLearnings.get_annotation_class()[column_index]
-            concepts = learning.get_winning_concepts()
+            concepts = learning.get_concepts()
             for concept in concepts:
+                print("UPDATE CONCEPTS SCORES FOR", concept)
                 learning.update_conceptScores(concept, table.columns[column_index], bow_domain)
             learning.preliminaryCellDisambiguation()
             currentLearnings.update_annotation_class(column_index, learning)


### PR DESCRIPTION
En la fase de update, se actualizan los scores (updateConceptScores) ya que en preliminaryColumnDisambiguation pudieron haber surgido nuevos concepts al recorrer TODAS las celdas de cada columna.
La funcion updateConceptScores estaba actualizando unicamente los scores de los conceptos con mayor score (winning concepts), y luego la fase "update" se aplicaba a todos los conceptos guardados (no solo a los ganadores). Se corrige esto, aplicando updateConceptsScores a TODOS los conceptos 