### PR TITLE
fix: subject column detection (missing values) y años

### DIFF
--- a/d3l/utils/constants.py
+++ b/d3l/utils/constants.py
@@ -5,6 +5,12 @@ from nltk.corpus import stopwords
 
 ADDITSTOPWORDS = ["yes", "no", "si"]
 STOPWORDS = stopwords.words('english') + stopwords.words('spanish') + ADDITSTOPWORDS
+MISSING_VALUES = [
+    "N/C", "NO CLASIFICADO", "NO CONSTA", "NA", "N/A", "ND", "NS", "NR",
+    "SIN INFORMACIÓN", "SIN REGISTRO", "DESCONOCIDO", "PENDIENTE",
+    "---", "...", "???", "", "NONE", "NULL", "NAN", "-1", "999", "S/N",
+    "S/R","S/I", "NC"]
+
 
 # Currency symbols ($)
 SYMBPATT = r"\@" + re.escape(


### PR DESCRIPTION
Se agregan missing_values (N/A, S/I, etc).  Cuando una celda está en missing_values, se clasifica como tipo "other" y se cuentan. Si la columna clasifica como tipo "other" pero la mayoria son missing_values, entonces se clasifica como el segundo mayor tipo encontrado en las celdas.


Se arregla clasificacion de año: cuando es tipo string pero es un número no se chequeaba si ese número es un año para clasificarlo como fecha 